### PR TITLE
Fix copy (proofread) and swap h1/h2 in first section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -181,7 +181,7 @@ p {
 
 .home_title {
     color: #fff;
-    font-size: 2em;
+    font-size: 3em;
 }
 
 .home-iphone {
@@ -201,7 +201,7 @@ p {
     }
 }
 
-.home_text h1 {
+.home_text h2 {
     color: #fff;
     text-transform: uppercase;
     font-size: 35px;
@@ -658,6 +658,9 @@ div.carousel-inner .item img {
     padding-bottom: 100px;
 }
 
+.call_to_action h2 {
+    color: white;
+}
 .call_to_action p {
     color: #dfdfdf;
     font-size: 18px;

--- a/index.html
+++ b/index.html
@@ -114,15 +114,14 @@
             <div class="container home-container">
                 <div class="row">
                     <div class="col-md-12">
-                        <h2 class="home_title home_text">Gulf Coast Tech Events</h2>
+                        <h1 class="home_title home_text">Gulf Coast Tech Events</h1>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-md-12 col-sm-12">
                         <div class="home_text">
                             <!-- TITLE AND DESC -->
-                            <h1>Your utlimate source of Technology events at gulf coast</h1>
-
+                            <h2>Your utlimate source of Technology events on the Gulf Coast</h2>
                         </div>
                     </div>
                 </div>
@@ -147,7 +146,9 @@
                     <!-- ABOUT US SECTION TITLE-->
                     <div class="section_title">
                         <h2>About Us</h2>
-                        <p>A place to find tech related events at gulf coast region to cultivate the technology community by providing education opportunities, an idea exchange platform, and bridging technologists with businesses.</p>
+                        <p>A place to find technology-related events in the Gulf Coast region and to cultivate the 
+                            community by providing education opportunities, an idea exchange platform, 
+                            and by bridging technologists with businesses.</p>
                     </div>
                 </div>
 
@@ -171,7 +172,10 @@
                     <!-- FEATURES SECTION TITLE -->
                     <div class="section_title wow fadeIn" data-wow-duration="2s">
                         <h2>Events</h2>
-                        <p>The growing community is composed of many people and events that glue them together. Here is the source you are finding the way to join and furnish the community that we can be proud of.</p>
+                        <p>
+                        Our growing community is composed of many people and the events that help to bring them together.
+                        Here are upcoming events to attend and to help the community grow!
+                        </p>
                     </div>
                     <!-- END FEATURES SECTION TITLE -->
                 </div>
@@ -228,7 +232,8 @@
         <div class="container ">
             <div class="row wow fadeInLeftBig " data-wow-duration="1s ">
                 <div class="col-md-9 ">
-                    <p>Submit your event today!</p>
+                    <h2>Submit your event today!</h2>
+                    <p>Have an event coming soon you'd like everyone to know about?  Submit your event here!</p>
                 </div>
                 <div class="col-md-3 ">
                     <a class="btn btn-primary btn-action " href="https://goo.gl/forms/wiszdm1KjpZb4rfZ2 " role="button ">Submit Now</a>
@@ -300,7 +305,7 @@
                     <!-- Start Contact Section Title-->
                     <div class="section_title ">
                         <h2>Get in touch</h2>
-                        <p>We would like to hear from you.</p>
+                        <p>We'd love to hear from you.</p>
                     </div>
                 </div>
             </div>
@@ -329,7 +334,7 @@
 
 
                             <div class="col-md-8 ">
-                                <textarea class="form-control " id="message" rows="25 " cols="10 " placeholder=" Message Texts... "></textarea>
+                                <textarea class="form-control " id="message" rows="25 " cols="10 " placeholder="Your message..."></textarea>
                                 <button type="button " class="btn btn-default submit-btn form_submit ">SEND MESSAGE</button>
                             </div>
                         </div>
@@ -370,8 +375,8 @@
 
                         <!-- Start Subscribe Section Title -->
                         <div class="section_title ">
-                            <h2>SUBSCRIBE US</h2>
-                            <p>Subscribe our newsletter to keep your finger on the pulse of technology community on the gulf coast.</p>
+                            <h2>SUBSCRIBE</h2>
+                            <p>Subscribe to our newsletter to keep your finger on the pulse of technology community on the gulf coast.</p>
                         </div>
                         <!-- End Subscribe Section Title -->
                     </div>


### PR DESCRIPTION
There should only be one `<h1>` on the page (or article section),
and it should reflect the main title/topic of the relevant page.

I feel these were likely swapped for styling reasons, so I've
swapped them back to be more semantically correct and modified
relevant styling to suite.